### PR TITLE
Fix bug when include same layout multiple times

### DIFF
--- a/compile/src/main/java/me/tatarka/holdr/compile/HoldrGenerator.java
+++ b/compile/src/main/java/me/tatarka/holdr/compile/HoldrGenerator.java
@@ -180,7 +180,7 @@ public class HoldrGenerator implements Serializable {
                 body.assign(fieldVar, cast(viewType, viewVar.invoke("findViewById").arg(idVar)));
             } else if (ref instanceof Include) {
                 JClass includeType = r.ref(getClassName(((Include) ref).layout));
-                body.assign(fieldVar, _new(includeType).arg(viewVar));
+                body.assign(fieldVar, _new(includeType).arg(viewVar.invoke("findViewById").arg(idVar)));
             }
         }
     }


### PR DESCRIPTION
Fix a bug when include same layout multiple times
From
```
cell4 = new Holdr_CellUnitExpMaterial(view);
cell3 = new Holdr_CellUnitExpMaterial(view);
...
```
To
```
cell4 = new Holdr_CellUnitExpMaterial(view.findViewById(R.id.cell_4));
cell3 = new Holdr_CellUnitExpMaterial(view.findViewById(R.id.cell_3));
...
```