### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ public class MyCustomView extends LinearLayout {
 ### Multiple layouts
 
 You may have multiple instances of a layout (in `layout` and `layout-land` for
-example). In that case Holdr will merge the id's accross them. If an id appears
+example). In that case Holdr will merge the id's across them. If an id appears
 in one and not the other, a `@Nullable` annotation will be generated to warn you
 of this.
 


### PR DESCRIPTION
@evant, I've corrected a typographical error in the documentation of the [holdr](https://github.com/evant/holdr) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.